### PR TITLE
Extend coverage of the client module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,5 @@ static-backend-mypy-strict:
 test-backend: ## Run backend tests
 	uv run pytest -vv -o log_cli=true -o log_cli_level=10 tests/backend/
 
+test-backend-coverage: ## Run backend tests with coverage
+	uv run pytest -vv --cov=app --cov-report=html -o log_cli=true -o log_cli_level=10 tests/backend/

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -150,3 +150,22 @@ def test_get_log_content_http_error(mock_openqa_client, app_logger):
         match="Failed to download log autoinst-log.txt for job 123: HTTP Error",
     ):
         wrapper.get_log_content("123", "autoinst-log.txt")
+
+
+def test_download_log_to_file_error_handling(mock_openqa_client, app_logger, tmp_path):
+    wrapper = OpenQAClientWrapper("https://fake.host/tests/1", app_logger)
+    destination_path = tmp_path / "autoinst-log.txt"
+    mock_openqa_client.session.get.side_effect = requests.exceptions.RequestException(
+        "Connection failed"
+    )
+
+    with pytest.raises(
+        OpenQAClientLogDownloadError, match="Failed to download log 'autoinst-log.txt' for job 1: Connection failed"
+    ):
+        wrapper.download_log_to_file("1", "autoinst-log.txt", str(destination_path))
+
+
+def test_get_job_url(app_logger):
+    client = OpenQAClientWrapper("https://fake.host/tests/1", app_logger)
+    actual = client.get_job_url("foo")
+    assert actual == "https://fake.host/tfoo"


### PR DESCRIPTION
The second commit just provide the flags to run test coverage

<img width="545" height="114" alt="image" src="https://github.com/user-attachments/assets/cb0c3412-99a0-43ec-92e9-cf5df014655b" />
